### PR TITLE
Adding a Markdown version of the TeX document

### DIFF
--- a/mac/mdrive.md
+++ b/mac/mdrive.md
@@ -1,0 +1,18 @@
+# Mounting a drive on Mac OSX.
+
+1. Open **Finder** by clicking on its icon on the far left of the
+Dock, at the bottom of the screen
+
+  ![Dock](images/mdrive-1.png)
+2. Open the **Go** menu at the top of the screen, and click **Connect
+to Server**
+
+  ![Go Menu Dropdown](images/mdrive-2.png)
+3. Enter `smb://smb1.aber.ac.uk/your_username` and click **Connect**.
+The contents of your `M:` drive should then appear
+
+  ![Prompt for mounting a drive](images/mdrive-3.png)
+4. To access your directory later on, open Finder again and look for
+`smb1.aber.ac.uk` in the sidebar
+
+  ![Finder side menu](images/mdrive-4.png)


### PR DESCRIPTION
Seeing as there is a current mix of LaTeX and Markdown versions of the documents, It seems only logical that the Mac instructions were also available in both formats.
